### PR TITLE
Use input for helm chart path instead of hard-coding

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,7 @@ runs:
       shell: bash
       run: |
         helm repo update
-        helm dependency update ./helm/smile-search-umbrella
+        helm dependency update ./${{ inputs.helm_chart_path }}
     - name: Set image version
       shell: bash
       run: |


### PR DESCRIPTION
Changing the helm chart path from an input to hard-coded value will allow us to reuse it for other apps.