### PR TITLE
Remove `helm repo update` call.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -33,7 +33,6 @@ runs:
       run: |
         export HELM_EXPERIMENTAL_OCI=1
         aws ecr get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin 877068819435.dkr.ecr.us-east-1.amazonaws.com
-        helm repo update
         helm dependency update ./${{ inputs.helm_chart_path }}
     - name: Set image version
       shell: bash


### PR DESCRIPTION
This command is no longer needed, as the GH runners don't have any configured repositories since we removed chartmuseum.